### PR TITLE
[sty] End_space_fix

### DIFF
--- a/example/in.f90
+++ b/example/in.f90
@@ -1,0 +1,33 @@
+program demo
+    integer :: endif,if,elseif
+    integer,DIMENSION(2) :: function
+    endif=3;if=2
+    if(endif==2)then
+    endif=5
+    elseif=if+4*(endif+&
+    2**10)
+    elseif(endif==3)then
+    function(if)=endif/elseif
+    print*,endif
+    write (*,*)"something"
+    endif
+
+endIF
+endDO
+endSELECT
+endASSOCIATE
+endBLOCK
+endSUBROUTINE
+endFUNCTION
+endMODULE
+endSUBMODULE
+endTYPE
+endPROGRAM
+endINTERFACE
+endENUM
+endWHERE
+endFORALL
+
+
+
+    end progra

--- a/example/in.f90
+++ b/example/in.f90
@@ -12,22 +12,22 @@ program demo
     write (*,*)"something"
     endif
 
-endIF
-endDO
+end IF
+end DO
+endif
+enddo
 endSELECT
 endASSOCIATE
 endBLOCK
 endSUBROUTINE
 endFUNCTION
-endMODULE
+end MODULE
 endSUBMODULE
-endTYPE
+end TYPE
 endPROGRAM
 endINTERFACE
 endENUM
-endWHERE
+end WHERE
 endFORALL
 
-
-
-    end progra
+end program

--- a/example/out.f90
+++ b/example/out.f90
@@ -9,6 +9,25 @@ program demo
   elseif (endif == 3) then
     function(if) = endif/elseif
     print *, endif
-    write (*, *) "something"
-  end if
+    write(*, *) "something"
+  endif
+
+  endIF
+endDO
+endif
+enddo
+end SELECT
+end ASSOCIATE
+end BLOCK
+end SUBROUTINE
+end FUNCTION
+end MODULE
+end SUBMODULE
+end TYPE
+end PROGRAM
+end INTERFACE
+end ENUM
+end WHERE
+end FORALL
+
 end program

--- a/example/out.f90
+++ b/example/out.f90
@@ -1,0 +1,14 @@
+program demo
+  integer :: endif, if, elseif
+  integer, DIMENSION(2) :: function
+  endif = 3; if = 2
+  if (endif == 2) then
+    endif = 5
+    elseif = if + 4*(endif + &
+                     2**10)
+  elseif (endif == 3) then
+    function(if) = endif/elseif
+    print *, endif
+    write (*, *) "something"
+  end if
+end program

--- a/examples/example_after.f90
+++ b/examples/example_after.f90
@@ -1,1 +1,0 @@
-../fortran_tests/after/example.f90

--- a/examples/example_before.f90
+++ b/examples/example_before.f90
@@ -1,1 +1,0 @@
-../fortran_tests/before/example.f90

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -196,7 +196,10 @@ FYPP_ENDMUTE_RE = re.compile(SOL_STR + r"#:ENDMUTE", RE_FLAGS)
 PRIVATE_RE = re.compile(SOL_STR + r"PRIVATE\s*::", RE_FLAGS)
 PUBLIC_RE = re.compile(SOL_STR + r"PUBLIC\s*::", RE_FLAGS)
 
-END_RE = re.compile(SOL_STR + r"(END)\s*(IF|DO|SELECT|ASSOCIATE|BLOCK|SUBROUTINE|FUNCTION|MODULE|SUBMODULE|TYPE|PROGRAM|INTERFACE|ENUM|WHERE|FORALL)", RE_FLAGS)
+END_RE = re.compile(SOL_STR + r"(END)\s*(SELECT|ASSOCIATE|BLOCK|SUBROUTINE|FUNCTION|MODULE|SUBMODULE|TYPE|PROGRAM|INTERFACE|ENUM|WHERE|FORALL)", RE_FLAGS)
+
+END_RE_NO = re.compile(SOL_STR + r"(END)\s*(IF|DO)", RE_FLAGS)
+
 
 # intrinsic statements with parenthesis notation that are not functions
 INTR_STMTS_PAR = (r"(FORALL|WHERE|ASSOCIATE|NULLIFY)")
@@ -1257,6 +1260,15 @@ def add_whitespace_charwise(line, spacey, scope_parser, format_decl, filename, l
     if is_end:
         line_ftd = END_RE.sub(r'\1' + ' '*spacey[8] + r'\2', line_ftd)
 
+    is_end_NO = False
+    if END_RE_NO.search(line_ftd):
+        for endre in scope_parser['end']:
+            if endre and endre.search(line_ftd):
+                is_end_NO = True
+                
+    if is_end_NO:
+        line_ftd = END_RE.sub(r'\1' + ' '*0 +  r'\2', line_ftd)
+        line_ftd = line_ftd.replace('end ', 'end').replace('END ', 'END').replace('End ', 'End')
     if level != 0:
         log_message('unpaired bracket delimiters', "info", filename, line_nr)
 


### PR DESCRIPTION
Quick change here. There were spaces in weird places with end. like `end if` instead of `endif`.We dodn't like that!


## CHANGES:

> ignore indentation, just look at spacing between end (if/do)

example in:

``` fortran
program demo
    integer :: endif,if,elseif
    integer,DIMENSION(2) :: function
    endif=3;if=2
    if(endif==2)then
    endif=5
    elseif=if+4*(endif+&
    2**10)
    elseif(endif==3)then
    function(if)=endif/elseif
    print*,endif
    write (*,*)"something"
    endif

end IF
end DO
endif
enddo
endSELECT
endASSOCIATE
endBLOCK
endSUBROUTINE
endFUNCTION
end MODULE
endSUBMODULE
end TYPE
endPROGRAM
endINTERFACE
endENUM
end WHERE
endFORALL
```

new output:

```fortran
program demo
  integer :: endif, if, elseif
  integer, DIMENSION(2) :: function
  endif = 3; if = 2
  if (endif == 2) then
    endif = 5
    elseif = if + 4*(endif + &
                     2**10)
  elseif (endif == 3) then
    function(if) = endif/elseif
    print *, endif
    write(*, *) "something"
  endif

  endIF
endDO
endif
enddo
end SELECT
end ASSOCIATE
end BLOCK
end SUBROUTINE
end FUNCTION
end MODULE
end SUBMODULE
end TYPE
end PROGRAM
end INTERFACE
end ENUM
end WHERE
end FORALL

end program
```

